### PR TITLE
refactor: convert data to ES module

### DIFF
--- a/data.mjs
+++ b/data.mjs
@@ -1,5 +1,5 @@
 // Events per second (baseline)
-const eventRates = [
+export const eventRates = [
   { name: "Star Birth", value: 1.8 },
   { name: "Star Quiet Fade", value: 1.2 },
   { name: "Star Catastrophic Death", value: 0.0001 },

--- a/index.html
+++ b/index.html
@@ -26,7 +26,6 @@
     <canvas id="eventChart"></canvas>
   </main>
 
-  <script src="data.js"></script>
-  <script src="script.js"></script>
+  <script type="module" src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,3 +1,4 @@
+import { eventRates } from './data.mjs';
 const ctx = document.getElementById('eventChart').getContext('2d');
 let isLog = false;
 


### PR DESCRIPTION
## Summary
- convert static data.js to data.mjs exporting `eventRates`
- import `eventRates` in script.js via ES modules
- load script.js as a module and drop old data.js include

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689629e5ce948330af9306104dc2077e