### PR TITLE
Trim whitespace from CSS variables for chart colors

### DIFF
--- a/script.js
+++ b/script.js
@@ -2,13 +2,14 @@ const ctx = document.getElementById('eventChart').getContext('2d');
 let isLog = false;
 
 function getColors() {
+  const style = getComputedStyle(document.body);
   return [
-    getComputedStyle(document.body).getPropertyValue('--accent1'),
-    getComputedStyle(document.body).getPropertyValue('--accent2'),
-    getComputedStyle(document.body).getPropertyValue('--accent3'),
-    getComputedStyle(document.body).getPropertyValue('--accent4'),
-    getComputedStyle(document.body).getPropertyValue('--accent5'),
-    getComputedStyle(document.body).getPropertyValue('--accent6')
+    style.getPropertyValue('--accent1').trim(),
+    style.getPropertyValue('--accent2').trim(),
+    style.getPropertyValue('--accent3').trim(),
+    style.getPropertyValue('--accent4').trim(),
+    style.getPropertyValue('--accent5').trim(),
+    style.getPropertyValue('--accent6').trim()
   ];
 }
 


### PR DESCRIPTION
## Summary
- Ensure chart color values are trimmed to avoid invalid CSS color strings
- Minor refactor: compute body style once when building color array

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689610a235c083309620e12bf13738ae